### PR TITLE
Fix typo and missing attribute in class X::Intl::LanguageTag::Invalid

### DIFF
--- a/lib/Intl/LanguageTag/X.pm6
+++ b/lib/Intl/LanguageTag/X.pm6
@@ -6,6 +6,8 @@ role X::Intl::LanguageTag { }
 
 
 class X::Intl::LangaugeTag::Invalid does X::Intl::LanguageTag {
+    has $.tag;
+
     method message { "Not possible to create language tag: \n"
                      ~ "‘{$!tag}’ is an invalid tag." }
 }

--- a/lib/Intl/LanguageTag/X.pm6
+++ b/lib/Intl/LanguageTag/X.pm6
@@ -5,7 +5,7 @@ unit module Exception;
 role X::Intl::LanguageTag { }
 
 
-class X::Intl::LangaugeTag::Invalid does X::Intl::LanguageTag {
+class X::Intl::LanguageTag::Invalid does X::Intl::LanguageTag {
     has $.tag;
 
     method message { "Not possible to create language tag: \n"


### PR DESCRIPTION
Hi
Was just trying to install Fluent package today, and yours here is a dependency. Test failed on the missing $.tag attribute, and then I noticed the typo.
I see those exception classes aren't actually used anywhere so looks like fixing the typo is "free" for now. Not sure if it might break anything else…
Regards,
Mark.